### PR TITLE
セルフ改造版

### DIFF
--- a/noreita/index.php
+++ b/noreita/index.php
@@ -810,7 +810,7 @@ function reply()
 			$c_pass = $pwd;
 			//-- クッキー保存 --
 			//クッキー項目："クッキー名 クッキー値"
-			$cookies = [["namec",$name],["emailc",$mail] , ["urlc", $url], ["pwdc", $c_pass] ,[ "palettec" . $pal]];
+			$cookies = [["namec",$name],["emailc",$mail] , ["urlc", $url], ["pwdc", $c_pass]];
 			foreach ($cookies as $cookie) {
 				list($c_name, $c_cookie) = $cookie;
 				setcookie($c_name, $c_cookie, time() + (SAVE_COOKIE * 24 * 3600));

--- a/noreita/index.php
+++ b/noreita/index.php
@@ -1284,12 +1284,8 @@ function paintform($rep)
 	global $blade, $dat;
 	global $pallets_dat;
 
-	$pwd = filter_input(INPUT_POST, 'pwd');
+	$pwd = (string)filter_input(INPUT_POST, 'pwd');
 	$imgfile = filter_input(INPUT_POST, 'img');
-
-	if (!$pwd) {
-		$pwd = "";
-	}
 
 	//ツール
 	if (isset($_POST["tools"])) {

--- a/noreita/index.php
+++ b/noreita/index.php
@@ -604,7 +604,7 @@ function regist()
 			$c_pass = $pwd;
 			//-- クッキー保存 --
 			//クッキー項目："クッキー名 クッキー値"
-			$cookies = ["namec\t" . $name, "emailc\t" . $mail, "urlc\t" . $url, "pwdc\t" . $c_pass . "palettec\t" . $pal];
+			$cookies = ["namec\t" . $name, "emailc\t" . $mail, "urlc\t" . $url, "pwdc\t" . $c_pass , "palettec\t" . $pal];
 
 			foreach ($cookies as $cookie) {
 				list($c_name, $c_cookie) = explode("\t", $cookie);

--- a/noreita/index.php
+++ b/noreita/index.php
@@ -581,7 +581,24 @@ function regist()
 			$shd = 0;
 			$age = 0;
 			$parent = NULL;
-			$sql = "INSERT INTO tlog (created, modified, thread, parent, comid, tree, a_name, sub, com, mail, a_url, picfile, pchfile, img_w, img_h, psec, utime, pwd, id, exid, age, invz, host, tool, admins, shd, ext01) VALUES (datetime('now', 'localtime'), datetime('now', 'localtime'), '$thread', '$parent', '$tree', '$tree', '$name', '$sub', '$com', '$mail', '$url', '$picfile', '$pchfile', '$img_w', '$img_h', '$psec', '$utime', '$pwdh', '$id', '$exid', '$age', '$invz', '$host', '$used_tool', '$admins', '$shd', '$nsfw')";
+			$sql = "INSERT INTO tlog (created, modified, thread, parent, comid, tree, a_name, sub, com, mail, a_url, picfile, pchfile, img_w, img_h, psec, utime, pwd, id, exid, age, invz, host, tool, admins, shd, ext01) VALUES (datetime('now', 'localtime'), datetime('now', 'localtime'), :thread, :parent, :tree, :tree, :name, :sub, :com, :mail, :url, :picfile, :pchfile, :img_w, :img_h, :psec, :utime, :pwdh, :id, :exid, :age, :invz, :host, :used_tool, :admins, :shd, :nsfw)";
+
+				// プレースホルダ
+				try
+				{
+				$stmt = $db->prepare($sql);
+
+				$stmt->execute(
+					[
+						'thread'=>$thread, 'parent'=>$parent, 'tree'=>$tree, 'name'=>$name,'sub'=>$sub,'com'=>$com,'mail'=>$mail,'url'=>$url,'picfile'=> $picfile,'pchfile'=> $pchfile, 'img_w'=>$img_w,'img_h'=> $img_h, 'psec'=>$psec,'utime'=> $utime,'pwdh'=> $pwdh,'id'=> $id,'exid'=> $exid,'age'=> $age,'invz'=> $invz,'host'=> $host,'used_tool'=> $used_tool,'admins'=> $admins,'shd'=> $shd,'nsfw'=> $nsfw,
+					]
+				);
+				}
+				catch(PDOException $e)
+				{
+					echo "DB接続エラー:" . $e->getMessage();
+				}
+
 			$db->exec($sql);
 
 			$c_pass = $pwd;
@@ -770,7 +787,24 @@ function reply()
 
 			//リプ処理
 			$thread = 0;
-			$sql = "INSERT INTO tlog (created, modified, thread, parent, comid, tree, a_name, sub, com, mail, a_url, pwd, id, exid, age, invz, host, admins) VALUES (datetime('now', 'localtime'), datetime('now', 'localtime'), '$thread', '$parent', '$comid', '$tree', '$name', '$sub', '$com', '$mail', '$url', '$pwdh', '$id', '$exid', '$age', '$invz', '$host', '$admins')";
+			$sql = "INSERT INTO tlog (created, modified, thread, parent, comid, tree, a_name, sub, com, mail, a_url, pwd, id, exid, age, invz, host, admins) VALUES (datetime('now', 'localtime'), datetime('now', 'localtime'), :thread, :parent, :comid, :tree, :name, :sub, :com, :mail, :url, :pwdh, :id, :exid, :age, :invz, :host, :admins)";
+			
+				// プレースホルダ
+				try
+				{
+				$stmt = $db->prepare($sql);
+	
+				$stmt->execute(
+					[
+						'thread'=>$thread, 'parent'=>$parent, 'comid'=>$comid,'tree'=>$tree, 'name'=>$name,'sub'=>$sub,'com'=>$com,'mail'=>$mail,'url'=>$url,'pwdh'=> $pwdh,'id'=> $id,'exid'=> $exid,'age'=> $age,'invz'=> $invz,'host'=> $host,'admins'=> $admins,
+					]
+				);
+				}
+				catch(PDOException $e)
+				{
+					echo "DB接続エラー:" . $e->getMessage();
+				}
+			
 			$db->exec($sql);
 
 			$c_pass = $pwd;

--- a/noreita/index.php
+++ b/noreita/index.php
@@ -604,7 +604,7 @@ function regist()
 			$c_pass = $pwd;
 			//-- クッキー保存 --
 			//クッキー項目："クッキー名 クッキー値"
-			$cookies = [["namec",$name],["emailc",$mail] , ["urlc", $url], ["pwdc", $c_pass] ,[ "palettec" . $pal]];
+			$cookies = [["namec",$name],["emailc",$mail] , ["urlc", $url], ["pwdc", $c_pass] ,[ "palettec" , $pal]];
 
 			foreach ($cookies as $cookie) {
 				list($c_name, $c_cookie) = $cookie;

--- a/noreita/index.php
+++ b/noreita/index.php
@@ -604,10 +604,10 @@ function regist()
 			$c_pass = $pwd;
 			//-- クッキー保存 --
 			//クッキー項目："クッキー名 クッキー値"
-			$cookies = ["namec\t" . $name, "emailc\t" . $mail, "urlc\t" . $url, "pwdc\t" . $c_pass , "palettec\t" . $pal];
+			$cookies = [["namec",$name],["emailc",$mail] , ["urlc", $url], ["pwdc", $c_pass] ,[ "palettec" . $pal]];
 
 			foreach ($cookies as $cookie) {
-				list($c_name, $c_cookie) = explode("\t", $cookie);
+				list($c_name, $c_cookie) = $cookie;
 				setcookie($c_name, $c_cookie, time() + (SAVE_COOKIE * 24 * 3600));
 			}
 
@@ -810,10 +810,9 @@ function reply()
 			$c_pass = $pwd;
 			//-- クッキー保存 --
 			//クッキー項目："クッキー名 クッキー値"
-			$cookies = ["namec\t" . $name, "emailc\t" . $mail, "urlc\t" . $url, "pwdc\t" . $c_pass . "palettec\t" . $pal];
-
+			$cookies = [["namec",$name],["emailc",$mail] , ["urlc", $url], ["pwdc", $c_pass] ,[ "palettec" . $pal]];
 			foreach ($cookies as $cookie) {
-				list($c_name, $c_cookie) = explode("\t", $cookie);
+				list($c_name, $c_cookie) = $cookie;
 				setcookie($c_name, $c_cookie, time() + (SAVE_COOKIE * 24 * 3600));
 			}
 

--- a/noreita/index.php
+++ b/noreita/index.php
@@ -1389,6 +1389,7 @@ function paintform($rep)
 	$pal = array();
 	$DynP = array();
 	$p_cnt = 0;
+	$arr_pal=[];
 	foreach ($lines as $i => $line) {
 		$line = charconvert(str_replace(["\r", "\n", "\t"], "", $line));
 		list($pid, $pname, $pal[0], $pal[2], $pal[4], $pal[6], $pal[8], $pal[10], $pal[1], $pal[3], $pal[5], $pal[7], $pal[9], $pal[11], $pal[12], $pal[13]) = explode(",", $line);
@@ -1410,7 +1411,7 @@ function paintform($rep)
 	//パスワード暗号化
 	$pwdf = openssl_encrypt($pwd, CRYPT_METHOD, CRYPT_PASS, true, CRYPT_IV); //暗号化
 	$pwdf = bin2hex($pwdf); //16進数に
-
+	$arr_dynp=[];
 	foreach ($DynP as $p) {
 		$arr_dynp[] = '<option>' . $p . '</option>';
 	}


### PR DESCRIPTION
このプルリクにはバグがあるかもしれませんが、一応はテストしました。
マージするしないの判断はおまかせします。
Cookie関連では、パスワードの値とパレットデータが結合した値がCookieにセットされるバグを修正しています。
ドットとカンマの違いだけですが、ドットになると、値が結合されてしまいます。
ChickenPaintのレイヤーを使用しない形での続きを描くは問題なく動作していましたが、レイヤーが2枚以上の場合は、続きを描くでパレットの項目が表示されないため、それが原因でPHP8.2環境でChickenPaintの続きを描くに失敗して致命的エラーが発生していました。
データーベースのSQLインジェクション対策として、INSERTで使う値が変数の時はプレースホルダーを使う方式に修正しました。
データベースを使っていない運営サイトに今でも毎日400回以上のSQLインジェクション攻撃がありますので、より安全な方式を採用してみました。

> プレースホルダとは？SQLインジェクション攻撃を回避せよ！
> https://blog.senseshare.jp/placeholder.html